### PR TITLE
Pin six version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ PasteDeploy
 influxdb==2.8.0
 pika
 python-surveilclient==0.13.3
-six
+six==1.9.0
 docker-py
 mongoengine


### PR DESCRIPTION
Image build fails with error: Installed distribution six 1.10.0 conflicts with requirement six==1.9.0 if six is not pinned to version 1.9.0
